### PR TITLE
refactor: Clean up imports and improve type safety in StockAnalyzer component

### DIFF
--- a/frontend/src/Indicator.tsx
+++ b/frontend/src/Indicator.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import axios from "axios";
-import { ChevronDown, Home, LayoutDashboard, Wallet, Newspaper, BarChart2, Users, Settings, Phone, ChevronUp } from 'lucide-react';
-import { BrowserRouter as Router, Routes, Route, Link, useNavigate } from 'react-router-dom';
+import { LayoutDashboard, Wallet, Newspaper, BarChart2 } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
 import './Indicator.css';
 
 interface StockResponse {
@@ -24,7 +24,7 @@ function StockAnalyzer() {
   const [company, setCompany] = useState("");
   const [ticker, setTicker] = useState("");
   const [ownedStock, setOwnedStock] = useState(false);
-  const [result, setResult] = useState<any>(null);
+  const [result, setResult] = useState<StockResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
 
@@ -48,7 +48,7 @@ function StockAnalyzer() {
     }
     setLoading(false);
   };
-  const [isOpen, setIsOpen] = useState(false);
+
   return (
     <div className="dashboard-container">
       <div className="dashboard-layout">


### PR DESCRIPTION
This pull request makes some minor improvements to the `StockAnalyzer` component in `Indicator.tsx`. The changes focus on cleaning up unused imports and improving type safety for the `result` state.

- **Code cleanup:**
  * Removed unused icon imports (`ChevronDown`, `Home`, `Users`, `Settings`, `Phone`, `ChevronUp`) and unused React Router imports (`Router`, `Routes`, `Route`, `Link`) from `Indicator.tsx`.

- **Type safety improvements:**
  * Updated the type of the `result` state from `any` to `StockResponse | null` for better type safety in the `StockAnalyzer` component.

- **State cleanup:**
  * Removed the unused `isOpen` state variable from the `StockAnalyzer` component.