### PR TITLE
Fix prediction training data, remove leaked API key, batch FinBERT inference

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,28 @@
+# Backend environment configuration.
+# Copy this file to `.env` and fill in real values. Do NOT commit `.env`.
+
+# === API Keys ===
+# NewsData.io API key used to fetch company news (https://newsdata.io).
+# Required — there is no fallback. The app cannot fetch news without it.
+NEWS_API_KEY=
+
+# === Model Configuration ===
+# Hugging Face model id for FinBERT sentiment analysis.
+FINBERT_MODEL=ProsusAI/finbert
+
+# === Database Configuration ===
+# Connection string for the database (if/when used by the backend).
+DATABASE_URL=
+
+# === Server Configuration ===
+HOST=0.0.0.0
+PORT=8000
+
+# === CORS Configuration ===
+# Comma-separated list of allowed origins, e.g. http://localhost:5173
+# Use * to allow all origins (not recommended for production).
+ALLOWED_ORIGINS=*
+
+# === Debugging / Logging ===
+# One of: true / 1 / yes to enable debug mode.
+DEBUG=False

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -13,9 +13,8 @@ class Config:
     """Centralized configuration for the backend application"""
 
     # === API Keys ===
-    NEWS_API_KEY = os.getenv(
-        "NEWS_API_KEY", "pub_6830389454d2be3370f4b9fd5786223c9d6ad"  # default fallback
-    )
+    # No hardcoded fallback — set NEWS_API_KEY in the environment / .env file.
+    NEWS_API_KEY = os.getenv("NEWS_API_KEY")
 
     # === Model Configuration ===
     FINBERT_MODEL = os.getenv("FINBERT_MODEL", "ProsusAI/finbert")
@@ -71,7 +70,8 @@ class Config:
     def summary(cls):
         """Prints key configuration values for debugging"""
         print(f"Loaded .env from: {ENV_PATH}")
-        print(f"NEWS_API_KEY: {cls.NEWS_API_KEY[:10]}...")
+        masked_key = f"{cls.NEWS_API_KEY[:10]}..." if cls.NEWS_API_KEY else "(not set)"
+        print(f"NEWS_API_KEY: {masked_key}")
         print(f"DATABASE_URL: {cls.DATABASE_URL}")
         print(f"HOST: {cls.HOST}")
         print(f"PORT: {cls.PORT}")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -16,7 +16,6 @@ from typing import List, Dict, Optional  # ensure Optional is available
 from sklearn.metrics import mean_squared_error, mean_absolute_error, r2_score
 import ta
 import asyncio
-from sklearn.ensemble import VotingRegressor
 
 # ============================================================
 # Configuration Import
@@ -113,48 +112,44 @@ def fetch_news(company: str) -> List[str]:
         return []
 
 
+def _signed_sentiment_scores(news_list: List[str]) -> List[float]:
+    """Run FinBERT once over the batch and return per-article signed scores.
+
+    Positive articles yield +score, negative yield -score, neutral yield 0.
+    """
+    results = sentiment_pipeline(news_list)
+    scores = []
+    for result in results:
+        label = result["label"]
+        score = result["score"]
+        if label == "positive":
+            scores.append(score)
+        elif label == "negative":
+            scores.append(-score)
+        else:
+            scores.append(0.0)
+    return scores
+
+
 def analyze_sentiment1(news_list: List[str]) -> float:
-    """Lightweight sentiment scoring"""
+    """Lightweight sentiment scoring (mean signed FinBERT score)."""
     if not news_list:
         return 0.0
-
     try:
-        sentiments = []
-        for news in news_list:
-            result = sentiment_pipeline(news)[0]
-            sentiment = result["label"]
-            score = result["score"]
-
-            if sentiment == "positive":
-                sentiments.append(score)
-            elif sentiment == "negative":
-                sentiments.append(-score)
-            else:
-                sentiments.append(0)
-        return float(np.mean(sentiments)) if sentiments else 0.0
+        scores = _signed_sentiment_scores(news_list)
+        return float(np.mean(scores)) if scores else 0.0
     except Exception as e:
         print(f"Error analyzing sentiment: {str(e)}")
         return 0.0
 
 
 def analyze_sentiment(news_list: List[str]) -> float:
-    """Detailed sentiment analysis"""
+    """Detailed sentiment analysis, scaled for the news-impact endpoint."""
     if not news_list:
         return 0.0
     try:
-        sentiments = []
-        for news in news_list:
-            result = sentiment_pipeline(news)[0]
-            sentiment = result["label"]
-            score = result["score"]
-            if sentiment == "positive":
-                sentiment_score = score * 10
-            elif sentiment == "negative":
-                sentiment_score = -score * 10
-            else:
-                sentiment_score = 0.0
-            sentiments.append(sentiment_score)
-        avg_sentiment = float(np.mean(sentiments)) if sentiments else 0.0
+        scores = _signed_sentiment_scores(news_list)
+        avg_sentiment = float(np.mean(scores)) * 10 if scores else 0.0
         return round(avg_sentiment * 2, 2)
     except Exception as e:
         print(f"Error analyzing sentiment: {str(e)}")
@@ -216,13 +211,20 @@ async def predict_stock(data: StockRequest):
 
         # Prepare training data
         features = ["Open", "High", "Low", "Close", "Volume"]
+        feature_cols = features + ["Sentiment"]
         stock_data["Sentiment"] = sentiment_score
         stock_data["Target"] = stock_data["Close"].shift(-data.forecast_out)
-        stock_data.fillna(method="ffill", inplace=True)
-        stock_data.dropna(inplace=True)
 
-        X = stock_data[features + ["Sentiment"]].values
-        y = stock_data["Target"].values
+        # Fill gaps in feature columns only; do NOT fabricate target labels.
+        stock_data[feature_cols] = stock_data[feature_cols].ffill()
+
+        # Train only on rows that have a real (known) future target.
+        train_data = stock_data.dropna(subset=feature_cols + ["Target"])
+        if train_data.empty:
+            return {"error": "Not enough data to train the model"}
+
+        X = train_data[feature_cols].values
+        y = train_data["Target"].values
         X_train, X_test, y_train, y_test = train_test_split(
             X, y, test_size=0.2, random_state=42
         )
@@ -234,10 +236,8 @@ async def predict_stock(data: StockRequest):
         svr = SVR(kernel="rbf", C=1e3, gamma=0.1)
         svr.fit(X_train_scaled, y_train)
 
-        ensemble_model = VotingRegressor(estimators=[("svr", svr)])
-        ensemble_model.fit(X_train_scaled, y_train)
-
-        last_data = stock_data[features + ["Sentiment"]].tail(data.forecast_out).values
+        # Forecast from the most recent rows (whose targets are not yet known).
+        last_data = stock_data[feature_cols].tail(data.forecast_out).values
         last_data_scaled = scaler.transform(last_data)
         predictions = svr.predict(last_data_scaled)
 
@@ -261,7 +261,17 @@ async def predict_stock(data: StockRequest):
         rmse = np.sqrt(mse)
         mae = mean_absolute_error(y_test, y_pred_test)
         r2 = r2_score(y_test, y_pred_test)
-        mape = np.mean(np.abs((y_test - y_pred_test) / y_test)) * 100
+        # Guard against division by zero in MAPE (skip zero-priced targets).
+        nonzero = y_test != 0
+        if np.any(nonzero):
+            mape = (
+                np.mean(
+                    np.abs((y_test[nonzero] - y_pred_test[nonzero]) / y_test[nonzero])
+                )
+                * 100
+            )
+        else:
+            mape = float("nan")
 
         print("\n==== MODEL EVALUATION METRICS ====")
         print(
@@ -355,19 +365,25 @@ async def news_impact(company: str):
                 "impact": 0.0,
                 "reasons": ["No relevant news found."],
             }
-        impact = analyze_sentiment(news_list)
+
+        # Run the (slow) FinBERT pipeline once per article and reuse the results.
+        results = sentiment_pipeline(news_list)
+
+        label_to_text = {"positive": "[Positive]", "negative": "[Negative]"}
+        scores = []
         reasons = []
-        for news in news_list:
-            result = sentiment_pipeline(news)[0]
-            sentiment_label = result["label"]
+        for news, result in zip(news_list, results):
+            label = result["label"]
             score = result["score"]
-            if sentiment_label == "positive":
-                sentiment_text = "[Positive]"
-            elif sentiment_label == "negative":
-                sentiment_text = "[Negative]"
+            if label == "positive":
+                scores.append(score * 10)
+            elif label == "negative":
+                scores.append(-score * 10)
             else:
-                sentiment_text = "[Neutral]"
-            reasons.append(f"{sentiment_text} {news[:150]}...")
+                scores.append(0.0)
+            reasons.append(f"{label_to_text.get(label, '[Neutral]')} {news[:150]}...")
+
+        impact = round(float(np.mean(scores)) * 2, 2) if scores else 0.0
         return {"company": company, "impact": float(impact), "reasons": reasons}
     except Exception as e:
         return {"error": f"Failed to analyze news impact: {str(e)}"}

--- a/backend/app/svm.py
+++ b/backend/app/svm.py
@@ -4,21 +4,30 @@ import pandas as pd
 from sklearn.svm import SVR, SVC
 from sklearn.model_selection import train_test_split, GridSearchCV
 from sklearn.preprocessing import StandardScaler
-from sklearn.metrics import mean_absolute_error, accuracy_score, mean_squared_error, r2_score
+from sklearn.metrics import (
+    mean_absolute_error,
+    accuracy_score,
+    mean_squared_error,
+    r2_score,
+)
 import matplotlib.pyplot as plt
 from typing import Tuple, List, Dict, Any
 import logging
 from datetime import datetime, timedelta
-#RELIANCE.NS
+
+# RELIANCE.NS
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+
 class StockPredictor:
-    def __init__(self, ticker: str, start_date: str, end_date: str, forecast_days: int = 7):
+    def __init__(
+        self, ticker: str, start_date: str, end_date: str, forecast_days: int = 7
+    ):
         """
         Initialize the StockPredictor class.
-        
+
         Args:
             ticker (str): Stock ticker symbol
             start_date (str): Start date for historical data (YYYY-MM-DD)
@@ -37,22 +46,24 @@ class StockPredictor:
     def fetch_stock_data(self) -> pd.DataFrame:
         """
         Fetch historical stock data from Yahoo Finance.
-        
+
         Returns:
             pd.DataFrame: Historical stock data
         """
         try:
             logger.info(f"Fetching data for {self.ticker}")
-            stock_data = yf.download(self.ticker, start=self.start_date, end=self.end_date)
-            
+            stock_data = yf.download(
+                self.ticker, start=self.start_date, end=self.end_date
+            )
+
             if stock_data.empty:
                 raise ValueError(f"No data found for ticker {self.ticker}")
-            
+
             # Calculate technical indicators
             stock_data = self._add_technical_indicators(stock_data)
             self.stock_data = stock_data
             return stock_data
-            
+
         except Exception as e:
             logger.error(f"Error fetching stock data: {str(e)}")
             raise
@@ -60,45 +71,45 @@ class StockPredictor:
     def _add_technical_indicators(self, df: pd.DataFrame) -> pd.DataFrame:
         """
         Add technical indicators to the dataset.
-        
+
         Args:
             df (pd.DataFrame): Stock data DataFrame
-            
+
         Returns:
             pd.DataFrame: DataFrame with added technical indicators
         """
         # Moving averages
-        df['SMA_5'] = df['Close'].rolling(window=5).mean()
-        df['SMA_20'] = df['Close'].rolling(window=20).mean()
-        
+        df["SMA_5"] = df["Close"].rolling(window=5).mean()
+        df["SMA_20"] = df["Close"].rolling(window=20).mean()
+
         # Relative Strength Index (RSI)
-        delta = df['Close'].diff()
+        delta = df["Close"].diff()
         gain = (delta.where(delta > 0, 0)).rolling(window=14).mean()
         loss = (-delta.where(delta < 0, 0)).rolling(window=14).mean()
         rs = gain / loss
-        df['RSI'] = 100 - (100 / (1 + rs))
-        
+        df["RSI"] = 100 - (100 / (1 + rs))
+
         # MACD
-        exp1 = df['Close'].ewm(span=12, adjust=False).mean()
-        exp2 = df['Close'].ewm(span=26, adjust=False).mean()
-        df['MACD'] = exp1 - exp2
-        df['Signal_Line'] = df['MACD'].ewm(span=9, adjust=False).mean()
-        
+        exp1 = df["Close"].ewm(span=12, adjust=False).mean()
+        exp2 = df["Close"].ewm(span=26, adjust=False).mean()
+        df["MACD"] = exp1 - exp2
+        df["Signal_Line"] = df["MACD"].ewm(span=9, adjust=False).mean()
+
         # Bollinger Bands
-        df['BB_middle'] = df['Close'].rolling(window=20).mean()
-        df['BB_upper'] = df['BB_middle'] + 2 * df['Close'].rolling(window=20).std()
-        df['BB_lower'] = df['BB_middle'] - 2 * df['Close'].rolling(window=20).std()
-        
+        df["BB_middle"] = df["Close"].rolling(window=20).mean()
+        df["BB_upper"] = df["BB_middle"] + 2 * df["Close"].rolling(window=20).std()
+        df["BB_lower"] = df["BB_middle"] - 2 * df["Close"].rolling(window=20).std()
+
         # Volume indicators
-        df['Volume_MA'] = df['Volume'].rolling(window=20).mean()
-        
+        df["Volume_MA"] = df["Volume"].rolling(window=20).mean()
+
         # Drop NaN values
         return df.dropna()
 
     def prepare_data(self) -> Tuple[np.ndarray, np.ndarray, np.ndarray, pd.DataFrame]:
         """
         Prepare data for SVM models.
-        
+
         Returns:
             Tuple containing:
             - X (np.ndarray): Feature matrix
@@ -108,156 +119,195 @@ class StockPredictor:
         """
         if self.stock_data is None:
             self.fetch_stock_data()
-            
+
         # Create features for prediction
-        feature_columns = ['Open', 'High', 'Low', 'Close', 'Volume', 
-                         'SMA_5', 'SMA_20', 'RSI', 'MACD', 'Signal_Line',
-                         'BB_middle', 'BB_upper', 'BB_lower', 'Volume_MA']
-        
+        feature_columns = [
+            "Open",
+            "High",
+            "Low",
+            "Close",
+            "Volume",
+            "SMA_5",
+            "SMA_20",
+            "RSI",
+            "MACD",
+            "Signal_Line",
+            "BB_middle",
+            "BB_upper",
+            "BB_lower",
+            "Volume_MA",
+        ]
+
         # For Regression: Predict the future closing price
-        self.stock_data['Target_Price'] = self.stock_data['Close'].shift(-self.forecast_days)
-        
-        # For Classification: Predict whether the price will go up (1) or down (0)
-        self.stock_data['Target_Direction'] = np.where(
-            self.stock_data['Close'].shift(-self.forecast_days) > self.stock_data['Close'], 1, 0
+        self.stock_data["Target_Price"] = self.stock_data["Close"].shift(
+            -self.forecast_days
         )
-        
+
+        # For Classification: Predict whether the price will go up (1) or down (0)
+        self.stock_data["Target_Direction"] = np.where(
+            self.stock_data["Close"].shift(-self.forecast_days)
+            > self.stock_data["Close"],
+            1,
+            0,
+        )
+
         # Prepare features and targets
-        X = self.stock_data[feature_columns].values[:-self.forecast_days]
-        y_regression = self.stock_data['Target_Price'].values[:-self.forecast_days]
-        y_classification = self.stock_data['Target_Direction'].values[:-self.forecast_days]
-        
+        X = self.stock_data[feature_columns].values[: -self.forecast_days]
+        y_regression = self.stock_data["Target_Price"].values[: -self.forecast_days]
+        y_classification = self.stock_data["Target_Direction"].values[
+            : -self.forecast_days
+        ]
+
         # Get last data points for prediction
         last_data = self.stock_data[feature_columns].tail(self.forecast_days)
-        
+
         return X, y_regression, y_classification, last_data
 
     def train_models(self, perform_gridsearch: bool = False) -> Dict[str, float]:
         """
         Train SVR and SVC models.
-        
+
         Args:
             perform_gridsearch (bool): Whether to perform GridSearchCV
-            
+
         Returns:
             Dict[str, float]: Dictionary containing model performance metrics
         """
         # Prepare data
         X, y_regression, y_classification, _ = self.prepare_data()
-        
+
         # Split data
-        X_train, X_test, y_reg_train, y_reg_test, y_cls_train, y_cls_test = train_test_split(
-            X, y_regression, y_classification, test_size=0.2, random_state=42
+        X_train, X_test, y_reg_train, y_reg_test, y_cls_train, y_cls_test = (
+            train_test_split(
+                X, y_regression, y_classification, test_size=0.2, random_state=42
+            )
         )
-        
+
         # Scale features
         X_train_scaled = self.scaler.fit_transform(X_train)
         X_test_scaled = self.scaler.transform(X_test)
-        
+
         # Train SVR
         if perform_gridsearch:
             svr_params = {
-                'C': [0.1, 1, 10, 100],
-                'gamma': ['scale', 'auto', 0.1, 0.01],
-                'kernel': ['rbf', 'linear']
+                "C": [0.1, 1, 10, 100],
+                "gamma": ["scale", "auto", 0.1, 0.01],
+                "kernel": ["rbf", "linear"],
             }
             self.svr_model = GridSearchCV(SVR(), svr_params, cv=5, n_jobs=-1)
         else:
-            self.svr_model = SVR(kernel='rbf', C=100, gamma='auto')
-            
+            self.svr_model = SVR(kernel="rbf", C=100, gamma="auto")
+
         self.svr_model.fit(X_train_scaled, y_reg_train)
-        
+
         # Train SVC
         if perform_gridsearch:
             svc_params = {
-                'C': [0.1, 1, 10, 100],
-                'gamma': ['scale', 'auto', 0.1, 0.01],
-                'kernel': ['rbf', 'linear']
+                "C": [0.1, 1, 10, 100],
+                "gamma": ["scale", "auto", 0.1, 0.01],
+                "kernel": ["rbf", "linear"],
             }
             self.svc_model = GridSearchCV(SVC(), svc_params, cv=5, n_jobs=-1)
         else:
-            self.svc_model = SVC(kernel='rbf', C=100, gamma='auto')
-            
+            self.svc_model = SVC(kernel="rbf", C=100, gamma="auto")
+
         self.svc_model.fit(X_train_scaled, y_cls_train)
-        
+
         # Calculate metrics
         svr_predictions = self.svr_model.predict(X_test_scaled)
         svc_predictions = self.svc_model.predict(X_test_scaled)
-        
+
         metrics = {
-            'svr_mae': mean_absolute_error(y_reg_test, svr_predictions),
-            'svr_mse': mean_squared_error(y_reg_test, svr_predictions),
-            'svr_r2': r2_score(y_reg_test, svr_predictions),
-            'svc_accuracy': accuracy_score(y_cls_test, svc_predictions)
+            "svr_mae": mean_absolute_error(y_reg_test, svr_predictions),
+            "svr_mse": mean_squared_error(y_reg_test, svr_predictions),
+            "svr_r2": r2_score(y_reg_test, svr_predictions),
+            "svc_accuracy": accuracy_score(y_cls_test, svc_predictions),
         }
-        
+
         logger.info(f"Model performance metrics: {metrics}")
         return metrics
 
     def predict(self) -> Dict[str, Any]:
         """
         Make predictions using trained models.
-        
+
         Returns:
             Dict[str, Any]: Dictionary containing predictions and their dates
         """
         if self.svr_model is None or self.svc_model is None:
             self.train_models()
-            
+
         _, _, _, last_data = self.prepare_data()
         last_data_scaled = self.scaler.transform(last_data)
-        
+
         # Make predictions
         price_predictions = self.svr_model.predict(last_data_scaled)
         direction_predictions = self.svc_model.predict(last_data_scaled)
-        
+
         # Generate future dates
         last_date = self.stock_data.index[-1]
         prediction_dates = [
-            (last_date + timedelta(days=i+1)).strftime('%Y-%m-%d')
+            (last_date + timedelta(days=i + 1)).strftime("%Y-%m-%d")
             for i in range(self.forecast_days)
         ]
-        
+
         return {
-            'dates': prediction_dates,
-            'price_predictions': price_predictions.tolist(),
-            'direction_predictions': direction_predictions.tolist()
+            "dates": prediction_dates,
+            "price_predictions": price_predictions.tolist(),
+            "direction_predictions": direction_predictions.tolist(),
         }
 
     def plot_predictions(self, predictions: Dict[str, Any]) -> None:
         """
         Plot the predictions.
-        
+
         Args:
             predictions (Dict[str, Any]): Dictionary containing predictions
         """
         plt.figure(figsize=(15, 10))
-        
+
         # Plot historical prices
         plt.subplot(2, 1, 1)
-        plt.plot(self.stock_data.index, self.stock_data['Close'], label='Historical Close Price')
-        
+        plt.plot(
+            self.stock_data.index,
+            self.stock_data["Close"],
+            label="Historical Close Price",
+        )
+
         # Plot predictions
-        prediction_dates = [datetime.strptime(date, '%Y-%m-%d') for date in predictions['dates']]
-        plt.plot(prediction_dates, predictions['price_predictions'], 
-                'r--', label='Predicted Price')
-        
-        plt.title(f'{self.ticker} Stock Price Prediction')
-        plt.xlabel('Date')
-        plt.ylabel('Price')
+        prediction_dates = [
+            datetime.strptime(date, "%Y-%m-%d") for date in predictions["dates"]
+        ]
+        plt.plot(
+            prediction_dates,
+            predictions["price_predictions"],
+            "r--",
+            label="Predicted Price",
+        )
+
+        plt.title(f"{self.ticker} Stock Price Prediction")
+        plt.xlabel("Date")
+        plt.ylabel("Price")
         plt.legend()
-        
+
         # Plot direction predictions
         plt.subplot(2, 1, 2)
-        direction_colors = ['g' if d == 1 else 'r' for d in predictions['direction_predictions']]
-        plt.bar(prediction_dates, predictions['direction_predictions'], 
-               color=direction_colors, alpha=0.5)
-        plt.title('Price Direction Prediction (Green=Up, Red=Down)')
-        plt.xlabel('Date')
-        plt.ylabel('Direction')
-        
+        direction_colors = [
+            "g" if d == 1 else "r" for d in predictions["direction_predictions"]
+        ]
+        plt.bar(
+            prediction_dates,
+            predictions["direction_predictions"],
+            color=direction_colors,
+            alpha=0.5,
+        )
+        plt.title("Price Direction Prediction (Green=Up, Red=Down)")
+        plt.xlabel("Date")
+        plt.ylabel("Direction")
+
         plt.tight_layout()
         plt.show()
+
 
 def main():
     """
@@ -265,27 +315,25 @@ def main():
     """
     # Example usage
     predictor = StockPredictor(
-        ticker='AAPL',
-        start_date='2020-01-01',
-        end_date='2024-01-30',
-        forecast_days=7
+        ticker="AAPL", start_date="2020-01-01", end_date="2024-01-30", forecast_days=7
     )
-    
+
     try:
         # Train models
         metrics = predictor.train_models(perform_gridsearch=True)
         logger.info(f"Training metrics: {metrics}")
-        
+
         # Make predictions
         predictions = predictor.predict()
         logger.info(f"Predictions: {predictions}")
-        
+
         # Plot results
         predictor.plot_predictions(predictions)
-        
+
     except Exception as e:
         logger.error(f"Error in main: {str(e)}")
         raise
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## What changed

Backend correctness, security, and efficiency fixes in the FastAPI app.

### Correctness — `/predict`
- **Stop fabricating training labels.** `Target = Close.shift(-forecast_out)` followed by `fillna(method="ffill")` invented targets for the last N rows from stale prices and then trained on them. Now the model trains only on rows with a real future target; the latest rows are used solely as forecast input.
- **Replace deprecated `fillna(method="ffill")`** with `.ffill()` (the `method=` form is removed in the pandas 2.x line).
- **Guard MAPE against divide-by-zero** by masking out zero-priced targets.
- **Add an empty-data guard** before training.

### Efficiency
- **Remove dead `VotingRegressor`** — it was built and `.fit()` on every request (a second expensive train pass) but never used; predictions came from the `svr` model.
- **Batch FinBERT inference.** `/news-impact` ran the pipeline twice over every article, and the sentiment helpers looped one inference per article. Extracted a shared `_signed_sentiment_scores()` that runs FinBERT once over the batch — per-request inference drops from N calls to 1.

### Security / config
- **Remove the hardcoded NewsData.io API key** that was committed as a fallback in `config.py`; `NEWS_API_KEY` now comes only from the environment.
- **Add `backend/.env.example`** documenting all config vars.

## Reviewer notes
- ⚠️ **The leaked API key is still in git history.** It should be **rotated** at NewsData.io — removing it from the file does not invalidate it.
- The `svm.py` diff is **pre-existing black formatting only** (it was already modified before these changes) and is functionally a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)